### PR TITLE
Add CB_TX_V3 support

### DIFF
--- a/electrum_dash/dash_tx.py
+++ b/electrum_dash/dash_tx.py
@@ -670,15 +670,13 @@ class DashCbTx(ProTxBase):
         if self.version > 1:
             assert len(self.merkleRootQuorums) == 32, \
                 f'{len(self.merkleRootQuorums)} not 32'
-            res += self.merkleRootQuorums
+            res += self.merkleRootQuorums               # merkleRootMNList
         if self.version > 2:
-            # assert len(self.bestCLHeightDiff) == 32, \
-            #     f'{len(self.bestCLHeightDiff)} not 32'
-            res += pack_varint(self.bestCLHeightDiff)              # bestCLHeightDiff
+            res += pack_varint(self.bestCLHeightDiff)   # bestCLHeightDiff
             assert len(self.bestCLSignature) == 96, \
                 f'{len(self.bestCLSignature)} not 96'
-            res += self.bestCLSignature               # bestCLSignature
-            res += struct.pack('<q', self.assetLockedAmount)               # assetLockedAmount
+            res += self.bestCLSignature                 # bestCLSignature
+            res += struct.pack('<q', self.assetLockedAmount)  # assetLockedAmount
         return res
 
     @classmethod

--- a/electrum_dash/tests/test_dash_tx.py
+++ b/electrum_dash/tests/test_dash_tx.py
@@ -44,7 +44,11 @@ CB_TX_D = {
     'merkleRootMNList': '76629a6e42fb519188f65889fd3ac020'
                         '1be87aa227462b5643e8bb2ec1d7a82a',
     'merkleRootQuorums': '',
-    'version': 1}
+    'version': 1,
+    'bestCLHeightDiff': 0,
+    'bestCLSignature': '',
+    'assetLockedAmount': 0,
+}
 
 
 CB_TX_V2 = (
@@ -66,7 +70,37 @@ CB_TX_V2_D = {
                          '27462b5643e8bb2ec1d7a82a'),
     'merkleRootQuorums': ('76629a6e42fb519188f65889fd3ac0201be87aa'
                           '227462b5643e8bb2ec1d7a82a'),
-    'version': 2}
+    'version': 2,
+    'bestCLHeightDiff': 0,
+    'bestCLSignature': '',
+    'assetLockedAmount': 0
+}
+
+CB_TX_V3 = (
+    '0300050001000000000000000000000000000000000000000000000000000000000000'
+    '0000ffffffff06035cbe0d0101ffffffff0397f4e127000000001976a914c69a0bda7d'
+    'aaae481be8def95e5f347a1d00a4b488ac94196f1600000000016a4dd5632500000000'
+    '1976a914c69a0bda7daaae481be8def95e5f347a1d00a4b488ac00000000af03005cbe'
+    '0d003c7a25cd3258d4141c1aca784232f28b92f94221c1d6add1c7221ebecffd201297'
+    '52cf4e10c95caefd2972782eb6ab4bc64170c148c9f32191be3f09d546a5e500b097da'
+    'dbd9741dabd85bec96ed8421499ec37aeb0ec48ff25c2a994a47e030ef1c5758bf1918'
+    'e4fd04c9f7b149df160800a9fdbf08311b93484e545a876e81e3408a4c8358f11ce2c9'
+    'c01206c39122875f9dbfea67e8953da4e63a1cd8551dfc94196f1600000000')
+
+CB_TX_V3_D = {
+    'height': 900700,
+    'merkleRootMNList': ('3c7a25cd3258d4141c1aca784232f28b92f94221'
+                         'c1d6add1c7221ebecffd2012'),
+    'merkleRootQuorums': ('9752cf4e10c95caefd2972782eb6ab4bc64170c1'
+                          '48c9f32191be3f09d546a5e5'),
+    'version': 3,
+    'bestCLHeightDiff': 0,
+    'bestCLSignature': (
+        'b097dadbd9741dabd85bec96ed8421499ec37aeb0ec48ff25c2a994a47e030ef'
+        '1c5758bf1918e4fd04c9f7b149df160800a9fdbf08311b93484e545a876e81e3'
+        '408a4c8358f11ce2c9c01206c39122875f9dbfea67e8953da4e63a1cd8551dfc'),
+    'assetLockedAmount': 376379796
+}
 
 
 PRO_REG_TX = (
@@ -436,6 +470,38 @@ class TestDashSpecTxSerialization(SequentialTestCase):
         assert extra2.version == extra.version
         assert extra2.height == extra.height
         assert extra2.merkleRootMNList == extra.merkleRootMNList
+
+    def test_dash_tx_cb_tx_v3(self):
+        tx = transaction.Transaction(CB_TX_V3)
+        deser = tx.to_json()
+        assert deser['version'] == 3
+        assert deser['tx_type'] == 5
+        extra_dict = deser['extra_payload']
+        assert extra_dict == CB_TX_V3_D
+        extra = tx.extra_payload
+        assert(str(extra))
+        assert extra.version == CB_TX_V3_D['version']
+        assert extra.height == CB_TX_V3_D['height']
+        assert len(extra.merkleRootMNList) == 32
+        assert extra.merkleRootMNList == bfh(CB_TX_V3_D['merkleRootMNList'])
+        assert len(extra.merkleRootQuorums) == 32
+        assert extra.merkleRootQuorums == bfh(CB_TX_V3_D['merkleRootQuorums'])
+        assert extra.bestCLHeightDiff == 0
+        assert len(extra.bestCLSignature) == 96
+        assert extra.bestCLSignature == bfh(CB_TX_V3_D['bestCLSignature'])
+        assert extra.assetLockedAmount == 376379796
+
+        ser = tx.serialize()
+        assert ser == CB_TX_V3
+
+        assert extra.to_hex_str() == CB_TX_V3[272:]
+        extra2 = ProTxBase.from_hex_str(SPEC_CB_TX, CB_TX_V3[272:])
+        assert extra2.version == extra.version
+        assert extra2.height == extra.height
+        assert extra2.merkleRootMNList == extra.merkleRootMNList
+        assert extra2.bestCLHeightDiff == extra.bestCLHeightDiff
+        assert extra2.bestCLSignature == extra.bestCLSignature
+        assert extra2.assetLockedAmount == extra.assetLockedAmount
 
     def test_dash_tx_pro_reg_tx(self):
         tx = transaction.Transaction(PRO_REG_TX)

--- a/electrum_dash/transaction.py
+++ b/electrum_dash/transaction.py
@@ -91,6 +91,15 @@ class MissingTxInputAmount(Exception):
 SIGHASH_ALL = 1
 
 
+struct_le_H = struct.Struct('<H')
+struct_le_I = struct.Struct('<I')
+struct_le_Q = struct.Struct('<Q')
+
+unpack_le_uint16_from = struct_le_H.unpack_from
+unpack_le_uint32_from = struct_le_I.unpack_from
+unpack_le_uint64_from = struct_le_Q.unpack_from
+
+
 class TxOutput:
     scriptpubkey: bytes
     value: Union[int, str]
@@ -307,6 +316,7 @@ class BCDataStream(object):
     def read_uint32(self): return self._read_num('<I')
     def read_int64(self): return self._read_num('<q')
     def read_uint64(self): return self._read_num('<Q')
+    def read_varint(self): return self._read_varint()
 
     def write_boolean(self, val): return self.write(b'\x01' if val else b'\x00')
     def write_char(self, val): return self._write_num('<b', val)
@@ -356,6 +366,32 @@ class BCDataStream(object):
         except Exception as e:
             raise SerializationError(e) from e
         return i
+
+    def _read_le_uint16(self):
+        result, = unpack_le_uint16_from(self.binary, self.cursor)
+        self.cursor += 2
+        return result
+
+    def _read_le_uint32(self):
+        result, = unpack_le_uint32_from(self.binary, self.cursor)
+        self.cursor += 4
+        return result
+
+    def _read_le_uint64(self):
+        result, = unpack_le_uint64_from(self.binary, self.cursor)
+        self.cursor += 8
+        return result
+
+    def _read_varint(self):
+        n = self.input[self.read_cursor]
+        self.read_cursor += 1
+        if n < 253:
+            return n
+        if n == 253:
+            return self._read_le_uint16()
+        if n == 254:
+            return self._read_le_uint32()
+        return self._read_le_uint64()
 
     def _write_num(self, format, num):
         s = struct.pack(format, num)

--- a/electrum_dash/transaction.py
+++ b/electrum_dash/transaction.py
@@ -28,8 +28,6 @@
 # Note: The deserialization code originally comes from ABE.
 
 import struct
-import traceback
-import sys
 import io
 import base64
 from typing import (Sequence, Union, NamedTuple, Tuple, Optional, Iterable,

--- a/electrum_dash/util.py
+++ b/electrum_dash/util.py
@@ -48,6 +48,7 @@ import random
 import secrets
 import functools
 from abc import abstractmethod, ABC
+from struct import Struct
 
 import attr
 import aiohttp
@@ -97,6 +98,20 @@ FILE_OWNER_MODE = stat.S_IREAD | stat.S_IWRITE
 
 class UnknownBaseUnit(Exception): pass
 
+
+def pack_varint(n):
+    pack_byte = Struct('B').pack
+    pack_le_uint16 = Struct('<H').pack
+    pack_le_uint32 = Struct('<I').pack
+    pack_le_uint64 = Struct('<Q').pack
+
+    if n < 253:
+        return pack_byte(n)
+    if n < 65536:
+        return pack_byte(253) + pack_le_uint16(n)
+    if n < 4294967296:
+        return pack_byte(254) + pack_le_uint32(n)
+    return pack_byte(255) + pack_le_uint64(n)
 
 def decimal_point_to_base_unit_name(dp: int) -> str:
     # e.g. 8 -> "DASH"


### PR DESCRIPTION
# Issue 

Electrum Dash misses v20 hardfork support. Actually, the wallet works well, as long as your wallet is not involved with the masternode payouts, which contains new hardfork coinbase changes. If it does, wallet stops syncing. This PR fixes that

# Things done
* Backported Coinbase v3 transactions from the ElectrumX (https://github.com/spesmilo/electrumx/pull/234) 
* Added a test for CB_TX_V3