### PR TITLE
Fix 'cannot deserialize' on AssetUnlock transactions

### DIFF
--- a/electrum_dash/address_synchronizer.py
+++ b/electrum_dash/address_synchronizer.py
@@ -313,7 +313,7 @@ class AddressSynchronizer(Logger):
             # BUT we track is_mine inputs in a txn, and during subsequent calls
             # of add_transaction tx, we might learn of more-and-more inputs of
             # being is_mine, as we roll the gap_limit forward
-            is_coinbase = tx.inputs()[0].is_coinbase_input()
+            is_coinbase = tx._tx_type == 9 or tx.inputs()[0].is_coinbase_input()
             tx_height = self.get_tx_height(tx_hash).height
             if not allow_unrelated:
                 # note that during sync, if the transactions are not properly sorted,

--- a/electrum_dash/transaction.py
+++ b/electrum_dash/transaction.py
@@ -647,7 +647,7 @@ class Transaction:
             tx._version = header
 
         n_vin = vds.read_compact_size()
-        if n_vin < 1:
+        if n_vin < 1 and tx._tx_type != 9:
             raise SerializationError('tx needs to have at least 1 input')
         tx._inputs = [parse_input(vds) for i in range(n_vin)]
         n_vout = vds.read_compact_size()


### PR DESCRIPTION
Fix invalid checks for DIP-0027

AssetUnlock transaction does not have inputs, and should be treated as coinbase

