### PR TITLE
Fix ProUpReg Transaction Version Causing bad-protx-sig Error

### DIFF
--- a/electrum_dash/protx.py
+++ b/electrum_dash/protx.py
@@ -362,7 +362,7 @@ class ProTxManager(Logger):
         PubKeyOperator = bfh(mn.pubkey_operator)
         KeyIdVoting = b58_address_to_hash160(mn.voting_addr)[1]
 
-        tx = DashProUpRegTx(1, bfh(mn.protx_hash)[::-1], mn.mode,
+        tx = DashProUpRegTx(2, bfh(mn.protx_hash)[::-1], mn.mode,
                             PubKeyOperator, KeyIdVoting, scriptPayout,
                             b'\x00'*32, b'\x00'*65)
         return tx


### PR DESCRIPTION
- Fixed an issue with the ProUpReg transaction version that was causing the `bad-protx-sig` error during registration.
- Addressed the signature validation bug, ensuring the transaction is processed correctly without signature mismatches.