### PR TITLE
wallet: add dust filtering to coin selection and UI controls

### DIFF
--- a/electrum_dash/gui/qt/main_window.py
+++ b/electrum_dash/gui/qt/main_window.py
@@ -1566,7 +1566,16 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger):
         )
 
         def on_dust_ui_changed(*args):
-            self.config.set_key('exclude_dust_from_coin_selection', self.exclude_dust_cb.isChecked(), save=True)
+            self.config.set_key(
+                'exclude_dust_from_coin_selection',
+                self.exclude_dust_cb.isChecked(),
+                save=True
+            )
+            # Recalculate available amount immediately
+            try:
+                self.update_available_amount()
+            except Exception:
+                pass
 
         self.exclude_dust_cb.stateChanged.connect(on_dust_ui_changed)
 

--- a/electrum_dash/gui/qt/main_window.py
+++ b/electrum_dash/gui/qt/main_window.py
@@ -38,7 +38,7 @@ import queue
 import asyncio
 from typing import Optional, TYPE_CHECKING, Sequence, List, Union
 
-from PyQt5.QtGui import QPixmap, QKeySequence, QIcon, QCursor, QFont
+from PyQt5.QtGui import QPixmap, QKeySequence, QIcon, QCursor, QFont, QIntValidator
 from PyQt5.QtCore import Qt, QRect, QStringListModel, QSize, pyqtSignal, QPoint
 from PyQt5.QtCore import QTimer
 from PyQt5.QtWidgets import (QMessageBox, QComboBox, QSystemTrayIcon, QTabWidget,
@@ -1523,8 +1523,9 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger):
         self.amount_e = BTCAmountEdit(self.get_decimal_point)
         self.payto_e = PayToEdit(self)
         self.payto_e.addPasteButton(self.app)
-        msg = _('Recipient of the funds.') + '\n\n'\
-              + _('You may enter a Dash address, a label from your list of contacts (a list of completions will be proposed), or an alias (email-like address that forwards to a Dash address)')
+        msg = _('Recipient of the funds.') + '\n\n' \
+              + _(
+            'You may enter a Dash address, a label from your list of contacts (a list of completions will be proposed), or an alias (email-like address that forwards to a Dash address)')
         payto_label = HelpLabel(_('Pay to'), msg)
         grid.addWidget(payto_label, 1, 0)
         grid.addWidget(self.payto_e, 1, 1, 1, -1)
@@ -1534,8 +1535,9 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger):
         self.payto_e.set_completer(completer)
         completer.setModel(self.completions)
 
-        msg = _('Description of the transaction (not mandatory).') + '\n\n'\
-              + _('The description is not sent to the recipient of the funds. It is stored in your wallet file, and displayed in the \'History\' tab.')
+        msg = _('Description of the transaction (not mandatory).') + '\n\n' \
+              + _(
+            'The description is not sent to the recipient of the funds. It is stored in your wallet file, and displayed in the \'History\' tab.')
         description_label = HelpLabel(_('Description'), msg)
         grid.addWidget(description_label, 2, 0)
         self.message_e = SizedFreezableLineEdit(width=700)
@@ -1554,7 +1556,31 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger):
         self.ps_cb = QCheckBox(_('PrivateSend'))
         self.ps_cb.stateChanged.connect(self.on_ps_cb)
         self.ps_cb.setVisible(True)
-        grid.addWidget(self.ps_cb, 3, 1)
+
+        # Dust exclusion options (threshold is in settings)
+        self.exclude_dust_cb = QCheckBox(_('Do not include dust'))
+        self.exclude_dust_cb.setChecked(bool(self.config.get('exclude_dust_from_coin_selection', True)))
+        self.exclude_dust_cb.setToolTip(
+            _('When enabled, small UTXOs below the dust threshold will not be automatically selected for spending. '
+              'Manual coin selection will still allow spending them.')
+        )
+
+        def on_dust_ui_changed(*args):
+            self.config.set_key('exclude_dust_from_coin_selection', self.exclude_dust_cb.isChecked(), save=True)
+
+        self.exclude_dust_cb.stateChanged.connect(on_dust_ui_changed)
+
+        # Place both checkboxes into a single widget (PrivateSend on top, dust option below)
+        ps_dust_vbox = QVBoxLayout()
+        ps_dust_vbox.setContentsMargins(0, 0, 0, 0)
+        ps_dust_vbox.setSpacing(2)
+        ps_dust_vbox.addWidget(self.ps_cb)
+        ps_dust_vbox.addWidget(self.exclude_dust_cb)
+        ps_dust_vbox.addStretch(1)
+
+        ps_dust_w = QWidget()
+        ps_dust_w.setLayout(ps_dust_vbox)
+        grid.addWidget(ps_dust_w, 3, 1, alignment=Qt.AlignVCenter)
 
         self.av_amnt = BTCAmountEdit(self.get_decimal_point)
         self.av_amnt.setEnabled(False)
@@ -1563,7 +1589,8 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger):
 
         msg = _('Amount to be sent.') + '\n\n' \
               + _('The amount will be displayed in red if you do not have enough funds in your wallet.') + ' ' \
-              + _('Note that if you have frozen some of your addresses, the available funds will be lower than your total balance.') + '\n\n' \
+              + _(
+            'Note that if you have frozen some of your addresses, the available funds will be lower than your total balance.') + '\n\n' \
               + _('Keyboard shortcut: type "!" to send all your coins.')
         amount_label = HelpLabel(_('Amount'), msg)
         grid.addWidget(amount_label, 4, 0)
@@ -1595,7 +1622,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger):
 
         self.extra_payload = ExtraPayloadWidget(self)
         self.extra_payload.hide()
-        msg = _('Extra payload.') + '\n\n'\
+        msg = _('Extra payload.') + '\n\n' \
               + _('Dash DIP2 Special Transaction extra payload.')
         self.extra_payload_label = HelpLabel(_('Extra payload'), msg)
         self.extra_payload_label.hide()
@@ -1605,7 +1632,8 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger):
         def reset_max(text):
             self.max_button.setChecked(False)
             enable = not bool(text) and not self.amount_e.isReadOnly()
-            #self.max_button.setEnabled(enable)
+            # self.max_button.setEnabled(enable)
+
         self.amount_e.textEdited.connect(reset_max)
         self.fiat_send_e.textEdited.connect(reset_max)
 

--- a/electrum_dash/gui/qt/settings_dialog.py
+++ b/electrum_dash/gui/qt/settings_dialog.py
@@ -27,8 +27,8 @@ import ast
 from typing import Optional, TYPE_CHECKING
 
 from PyQt5.QtCore import Qt
-from PyQt5.QtWidgets import (QComboBox,  QTabWidget,
-                             QSpinBox,  QFileDialog, QCheckBox, QLabel,
+from PyQt5.QtWidgets import (QComboBox, QTabWidget,
+                             QSpinBox, QFileDialog, QCheckBox, QLabel,
                              QVBoxLayout, QGridLayout, QLineEdit,
                              QPushButton, QWidget, QHBoxLayout)
 
@@ -78,7 +78,9 @@ class SettingsDialog(WindowModalDialog):
             index = 0
         lang_combo.setCurrentIndex(index)
         if not self.config.is_modifiable('language'):
-            for w in [lang_combo, lang_label]: w.setEnabled(False)
+            for w in [lang_combo, lang_label]:
+                w.setEnabled(False)
+
         def on_lang(x):
             lang_request = list(languages.keys())[lang_combo.currentIndex()]
             if lang_request != self.config.get('language'):
@@ -184,6 +186,35 @@ class SettingsDialog(WindowModalDialog):
                win.wallet.storage.write_attempts = write_attempts
         wr_attempts_sb.valueChanged.connect(on_wr_attempts_set_value)
         gui_widgets.append((wr_attempts_lb, wr_attempts_sb))
+
+        # Dust threshold (used by "Do not include dust" and automatic coin selection)
+        dust_help = (
+            _('Minimum UTXO value that is considered "dust" for automatic coin selection.') + '\n\n' +
+            _('When "Do not include dust" is enabled, UTXOs below this value will not be automatically selected.') + '\n' +
+            _('Manual coin selection can still spend them.') + '\n\n' +
+            _('Unit: duffs (1 DASH = 100,000,000 duffs).')
+        )
+        dust_label = HelpLabel(_('Dust threshold (duffs)') + ':', dust_help)
+        dust_sb = QSpinBox()
+        dust_sb.setMinimum(0)
+        dust_sb.setMaximum(100_000_000)  # up to 1 DASH
+        dust_sb.setSingleStep(100)
+        dust_sb.setValue(int(self.config.get('dust_threshold_duffs', 10000)))
+
+        if not self.config.is_modifiable('dust_threshold_duffs'):
+            for w in [dust_label, dust_sb]:
+                w.setEnabled(False)
+
+        def on_dust_threshold_changed(v):
+            self.config.set_key('dust_threshold_duffs', int(v), save=True)
+            # Best-effort UI refresh
+            try:
+                self.window.utxo_list.update()
+            except Exception:
+                pass
+
+        dust_sb.valueChanged.connect(on_dust_threshold_changed)
+        gui_widgets.append((dust_label, dust_sb))
 
         show_dip2_cb = QCheckBox(_('Show transaction type in wallet history'))
         def_dip2 = not self.window.wallet.psman.unsupported

--- a/electrum_dash/tests/test_dash_ps.py
+++ b/electrum_dash/tests/test_dash_ps.py
@@ -9,6 +9,9 @@ import time
 from collections import defaultdict, Counter
 from pprint import pprint
 
+from unittest import mock
+from electrum_dash import wallet as wallet_mod
+
 from electrum_dash import dash_ps, ecc
 from electrum_dash.address_synchronizer import (TX_HEIGHT_LOCAL,
                                                 TX_HEIGHT_UNCONF_PARENT,
@@ -4595,3 +4598,59 @@ class PSWalletTestCase(TestCaseForTestnet):
         w = self.wallet
         psman = w.psman
         psman.get_all_known_addresses_beyond_gap_limit()
+
+    class _FakeUTXO:
+        def __init__(self, value):
+            self._value = value
+
+        def value_sats(self):
+            return self._value
+
+    @mock.patch.object(wallet_mod.Abstract_Wallet, 'save_db')
+    def test_dust_filter_filters_when_enabled(self, mock_save_db):
+        self.config.set_key('exclude_dust_from_coin_selection', True, save=False)
+        self.config.set_key('dust_threshold_duffs', 10000, save=False)
+
+        utxos = [self._FakeUTXO(5000), self._FakeUTXO(10000), self._FakeUTXO(25000)]
+        with mock.patch.object(self.wallet, 'get_utxos', return_value=utxos), \
+             mock.patch.object(self.wallet, 'is_frozen_coin', return_value=False):
+            coins = self.wallet.get_spendable_coins(domain=None)
+
+        assert len(coins) == 2
+        assert all(c.value_sats() >= 10000 for c in coins)
+
+    @mock.patch.object(wallet_mod.Abstract_Wallet, 'save_db')
+    def test_dust_filter_skips_when_disabled(self, mock_save_db):
+        self.config.set_key('exclude_dust_from_coin_selection', False, save=False)
+        self.config.set_key('dust_threshold_duffs', 10000, save=False)
+
+        utxos = [self._FakeUTXO(1), self._FakeUTXO(5000), self._FakeUTXO(9999)]
+        with mock.patch.object(self.wallet, 'get_utxos', return_value=utxos), \
+             mock.patch.object(self.wallet, 'is_frozen_coin', return_value=False):
+            coins = self.wallet.get_spendable_coins(domain=None)
+
+        assert len(coins) == 3
+
+    @mock.patch.object(wallet_mod.Abstract_Wallet, 'save_db')
+    def test_dust_filter_fallback_when_all_dust(self, mock_save_db):
+        self.config.set_key('exclude_dust_from_coin_selection', True, save=False)
+        self.config.set_key('dust_threshold_duffs', 10000, save=False)
+
+        utxos = [self._FakeUTXO(1), self._FakeUTXO(500)]
+        with mock.patch.object(self.wallet, 'get_utxos', return_value=utxos), \
+             mock.patch.object(self.wallet, 'is_frozen_coin', return_value=False):
+            coins = self.wallet.get_spendable_coins(domain=None)
+
+        assert len(coins) == 2
+
+    @mock.patch.object(wallet_mod.Abstract_Wallet, 'save_db')
+    def test_dust_filter_disabled_by_domain_coins(self, mock_save_db):
+        self.config.set_key('exclude_dust_from_coin_selection', True, save=False)
+        self.config.set_key('dust_threshold_duffs', 10000, save=False)
+
+        utxos = [self._FakeUTXO(1), self._FakeUTXO(5000), self._FakeUTXO(20000)]
+        with mock.patch.object(self.wallet, 'get_utxos', return_value=utxos), \
+             mock.patch.object(self.wallet, 'is_frozen_coin', return_value=False):
+            coins = self.wallet.get_spendable_coins(domain=None, domain_coins=['manual'])
+
+        assert len(coins) == 3

--- a/electrum_dash/wallet.py
+++ b/electrum_dash/wallet.py
@@ -605,7 +605,8 @@ class Abstract_Wallet(AddressSynchronizer, ABC):
 
     def get_spendable_coins(self, domain, *, nonlocal_only=False,
                             include_ps=False, min_rounds=None,
-                            no_ps_data=False, main_ks=False) -> Sequence[PartialTxInput]:
+                            no_ps_data=False, main_ks=False,
+                            domain_coins=None) -> Sequence[PartialTxInput]:
         confirmed_only = self.config.get('confirmed_only', False)
         get_min_rounds = None if no_ps_data else min_rounds
         with self._freeze_lock:
@@ -631,6 +632,22 @@ class Abstract_Wallet(AddressSynchronizer, ABC):
         if self.psman.enabled and include_ps and not self.psman.allow_others:
             utxos = [utxo for utxo in utxos
                      if utxo.ps_rounds != PSCoinRounds.OTHER]
+
+        # Exclude dust coins from automatic selection (UI-controlled)
+        # Manual coin control (domain_coins) disables dust filtering
+        if domain_coins is None:
+            exclude_dust = self.config.get('exclude_dust_from_coin_selection', True)
+            dust_threshold_duffs = self.config.get('dust_threshold_duffs', 10000)
+
+            if exclude_dust:
+                # Dust UTXO: utxo.value_sats() < dust_threshold_duffs
+                non_dust = [utxo for utxo in utxos if utxo.value_sats() >= dust_threshold_duffs]
+
+                # Edge case: wallet has only dust coins.
+                # Do not permanently block sending, fall back to original list.
+                if non_dust:
+                    utxos = non_dust
+
         return utxos
 
     @abstractmethod
@@ -2160,7 +2177,7 @@ class Abstract_Wallet(AddressSynchronizer, ABC):
               unsigned=False, password=None, locktime=None):
         if fee is not None and feerate is not None:
             raise Exception("Cannot specify both 'fee' and 'feerate' at the same time!")
-        coins = self.get_spendable_coins(domain_addr)
+        coins = self.get_spendable_coins(domain_addr, domain_coins=domain_coins)
         if domain_coins is not None:
             coins = [coin for coin in coins if (coin.prevout.to_str() in domain_coins)]
         if feerate is not None:


### PR DESCRIPTION
This PR introduces optional dust filtering in `get_spendable_coins()`.

### Wallet

* Add exclusion of small UTXOs based on configurable `dust_threshold_duffs`
* Filtering applies only to automatic coin selection
* Manual coin control (`domain_coins`) bypasses dust filtering
* If all available coins are below threshold, fallback to original list to avoid blocking spending

### GUI

* Send tab:

  * Add checkbox **"Do not include dust"**
* Settings → General:

  * Add configurable **"Dust threshold (duffs)"** field

The feature is enabled by default.
Default threshold: `10000` duffs.


<img width="2212" height="465" alt="image" src="https://github.com/user-attachments/assets/998bd07c-5225-4275-9db2-6a2e0517960e" />
