### PR TITLE
Add support for Dash Evolution (EvoNode) registration

### DIFF
--- a/contrib/requirements/requirements.txt
+++ b/contrib/requirements/requirements.txt
@@ -13,3 +13,5 @@ Pygments>=2.1
 # Note that we also need the dnspython[DNSSEC] extra which pulls in cryptography,
 # but as that is not pure-python it cannot be listed in this file!
 dnspython>=2.0,<2.1
+
+PyNaCl==1.6.2

--- a/electrum_dash/dash_tx.py
+++ b/electrum_dash/dash_tx.py
@@ -276,7 +276,9 @@ class DashProRegTx(ProTxBase):
         "version type mode collateralOutpoint "
         "ipAddress port KeyIdOwner PubKeyOperator "
         "KeyIdVoting operatorReward scriptPayout "
-        "inputsHash payloadSig"
+        "inputsHash "
+        "platformNodeID platformP2PPort platformHTTPPort "
+        "payloadSig"
     ).split()
 
     def __init__(self, *args, **kwargs):
@@ -310,63 +312,102 @@ class DashProRegTx(ProTxBase):
         )
 
     def serialize(self, full=True):
+        # --- sanity checks for base fields ---
         assert len(self.KeyIdOwner) == 20, f"{len(self.KeyIdOwner)} not 20"
         assert len(self.PubKeyOperator) == 48, f"{len(self.PubKeyOperator)} not 48"
         assert len(self.KeyIdVoting) == 20, f"{len(self.KeyIdVoting)} not 20"
         assert len(self.inputsHash) == 32, f"{len(self.inputsHash)} not 32"
 
+        # --- serialize ipAddress/port ---
         if self.ipAddress:
             ip_obj = ip_address(self.ipAddress)
             ip_bytes = serialize_ip(ip_obj)
-            port = self.port
+            port = int(self.port)
         else:
             ip_bytes = b"\x00" * 16
             port = 0
+
+        # --- evo node validation (type == 1) ---
+        if getattr(self, "type", 0) == 1:
+            platform_id = getattr(self, "platformNodeID", b"") or b""
+            if len(platform_id) != 20:
+                raise ValueError("platformNodeID must be exactly 20 bytes for evolution masternode")
+
+            p2p_port = getattr(self, "platformP2PPort", None)
+            http_port = getattr(self, "platformHTTPPort", None)
+
+            if p2p_port is None or not (1 <= int(p2p_port) <= 65535):
+                raise ValueError(f"Invalid platformP2PPort: {p2p_port}")
+            if http_port is None or not (1 <= int(http_port) <= 65535):
+                raise ValueError(f"Invalid platformHTTPPort: {http_port}")
+
+            if int(p2p_port) == int(http_port):
+                raise ValueError("platformP2PPort and platformHTTPPort must differ")
 
         # payloadSig must be encoded as varbytes on wire.
         # If signature is empty, it is encoded as CompactSize(0) which is a single 0x00 byte.
         # When full=False (hashing for signing), payloadSig must be excluded entirely.
         payload_sig_bytes = to_varbytes(self.payloadSig) if full else b""
 
-        return (
-            struct.pack("<H", self.version)  # version
-            + struct.pack("<H", self.type)  # type
-            + struct.pack("<H", self.mode)  # mode
-            + self.collateralOutpoint.serialize()  # collateralOutpoint
-            + ip_bytes  # ipAddress
-            + struct.pack(">H", port)  # port (network byte order)
-            + self.KeyIdOwner  # KeyIdOwner
-            + self.PubKeyOperator  # PubKeyOperator
-            + self.KeyIdVoting  # KeyIdVoting
-            + struct.pack("<H", self.operatorReward)  # operatorReward
-            + to_varbytes(self.scriptPayout)  # scriptPayout
-            + self.inputsHash  # inputsHash
-            + payload_sig_bytes  # payloadSig (varbytes)
-        )
+        out = bytearray()
+        out += struct.pack("<H", int(self.version))  # version
+        out += struct.pack("<H", int(self.type))  # type
+        out += struct.pack("<H", int(self.mode))  # mode
+        out += self.collateralOutpoint.serialize()  # collateralOutpoint
+        out += ip_bytes  # ipAddress
+        out += struct.pack(">H", int(port))  # port (network byte order)
+        out += self.KeyIdOwner  # KeyIdOwner
+        out += self.PubKeyOperator  # PubKeyOperator
+        out += self.KeyIdVoting  # KeyIdVoting
+        out += struct.pack("<H", int(self.operatorReward))  # operatorReward
+        out += to_varbytes(self.scriptPayout)  # scriptPayout
+        out += self.inputsHash  # inputsHash
+
+        # --- evo node extra fields (type == 1) ---
+        if getattr(self, "type", 0) == 1:
+            platform_id = getattr(self, "platformNodeID", b"") or b""
+            out += platform_id
+            # NOTE: Keep LE here for now to match existing behavior until LE/BE is clarified
+            out += struct.pack("<H", int(self.platformP2PPort))
+            out += struct.pack("<H", int(self.platformHTTPPort))
+
+        out += payload_sig_bytes  # payloadSig (varbytes)
+        return bytes(out)
 
     @classmethod
     def read_vds(cls, vds):
-        version = vds.read_uint16()              # version
-        mn_type = vds.read_uint16()              # type
-        mode = vds.read_uint16()                 # mode
+        version = vds.read_uint16()  # version
+        mn_type = vds.read_uint16()  # type
+        mode = vds.read_uint16()  # mode
         collateralOutpoint = read_outpoint(vds)  # collateralOutpoint
-        ip_bytes = vds.read_bytes(16)            # ipAddress
-        port = read_uint16_nbo(vds)              # port
-        KeyIdOwner = vds.read_bytes(20)          # KeyIdOwner
-        PubKeyOperator = vds.read_bytes(48)      # PubKeyOperator
-        KeyIdVoting = vds.read_bytes(20)         # KeyIdVoting
-        operatorReward = vds.read_uint16()       # operatorReward
-        scriptPayout = read_varbytes(vds)        # scriptPayout
-        inputsHash = vds.read_bytes(32)          # inputsHash
+        ip_bytes = vds.read_bytes(16)  # ipAddress
+        port = read_uint16_nbo(vds)  # port
+        KeyIdOwner = vds.read_bytes(20)  # KeyIdOwner
+        PubKeyOperator = vds.read_bytes(48)  # PubKeyOperator
+        KeyIdVoting = vds.read_bytes(20)  # KeyIdVoting
+        operatorReward = vds.read_uint16()  # operatorReward
+        scriptPayout = read_varbytes(vds)  # scriptPayout
+        inputsHash = vds.read_bytes(32)  # inputsHash
+
+        platformNodeID = b""
+        platformP2PPort = 0
+        platformHTTPPort = 0
+
+        # --- evo node extra fields (type == 1), if present ---
+        if mn_type == 1:
+            remaining = len(vds.input) - vds.read_cursor
+            # Need at least 24 bytes for platform fields + at least 1 byte for payloadSig CompactSize
+            if remaining >= 20 + 2 + 2 + 1:
+                platformNodeID = vds.read_bytes(20)
+                # NOTE: Keep LE here for now to match serialize() until LE/BE is clarified
+                platformP2PPort = vds.read_uint16()
+                platformHTTPPort = vds.read_uint16()
 
         # payloadSig is varbytes in practice and can be empty.
         payloadSig = read_varbytes(vds)
 
         ip_obj = ip_address(bytes(ip_bytes))
-        if ip_obj.ipv4_mapped:
-            ip_str = str(ip_obj.ipv4_mapped)
-        else:
-            ip_str = str(ip_obj)
+        ip_str = str(ip_obj.ipv4_mapped) if ip_obj.ipv4_mapped else str(ip_obj)
 
         return DashProRegTx(
             version,
@@ -381,14 +422,19 @@ class DashProRegTx(ProTxBase):
             operatorReward,
             scriptPayout,
             inputsHash,
+            platformNodeID,
+            platformP2PPort,
+            platformHTTPPort,
             payloadSig,
         )
 
     def update_with_tx_data(self, tx):
         if self.collateralOutpoint.hash_is_null:
+            target_value = (4000 * COIN) if getattr(self, "type", 0) == 1 else (1000 * COIN)
+
             found_idx = -1
             for i, o in enumerate(tx.outputs()):
-                if o.value == 1000 * COIN:
+                if o.value == target_value:
                     found_idx = i
                     break
             if found_idx >= 0:
@@ -398,8 +444,7 @@ class DashProRegTx(ProTxBase):
             TxOutPoint(bfh(i.prevout.txid.hex())[::-1], i.prevout.out_idx)
             for i in tx.inputs()
         ]
-        outpoints_ser = [o.serialize() for o in outpoints]
-        self.inputsHash = sha256d(b"".join(outpoints_ser))
+        self.inputsHash = sha256d(b"".join(o.serialize() for o in outpoints))
 
     def check_after_tx_prepared(self, tx):
         outpoints = [
@@ -436,6 +481,11 @@ class DashProRegTx(ProTxBase):
         )
 
         if len(coins) == 1:
+            # --- evo collateral validation (requires knowing UTXO amount) ---
+            if getattr(self, "type", 0) == 1:
+                if int(coins[0].value_sats()) != 4000 * COIN:
+                    raise DashTxError("Evolution masternode requires 4000 DASH collateral")
+
             coll_address = coins[0].address
             payload_hash = bh2u(sha256d(self.serialize(full=False))[::-1])
             payload_sig_msg = self.payload_sig_msg_part + payload_hash

--- a/electrum_dash/gui/qt/protx_wizards.py
+++ b/electrum_dash/gui/qt/protx_wizards.py
@@ -182,11 +182,9 @@ class OperationTypeWizardPage(QWizardPage):
         self.setTitle(_('Operation type'))
         self.setSubTitle(_('Select operation type and ownership properties.'))
 
-        self.rb_import = QRadioButton(_('Import and register legacy '
-                                        'masternode.conf as DIP3 Masternode'))
-        self.rb_create = QRadioButton(_('Create and register DIP3 Masternode'))
-        self.rb_connect = QRadioButton(_('Connect to registered DIP3 '
-                                         'Masternode'))
+        self.rb_import = QRadioButton(_('Import and register legacy masternode.conf as Masternode'))
+        self.rb_create = QRadioButton(_('Create and register Masternode'))
+        self.rb_connect = QRadioButton(_('Connect to registered Masternode'))
         self.rb_create.setChecked(True)
         self.rb_connect.setEnabled(False)
         self.button_group = QButtonGroup()
@@ -208,7 +206,7 @@ class OperationTypeWizardPage(QWizardPage):
         self.cb_operator.setChecked(True)
         self.cb_operator.stateChanged.connect(self.cb_state_changed)
 
-        self.cb_evonode = QCheckBox(_('Register as EvoNode (Platform enabled)'))
+        self.cb_evonode = QCheckBox(_('Register as EvoNode (4000 Dash)'))
         self.cb_evonode.setChecked(False)
         self.cb_evonode.stateChanged.connect(self.cb_state_changed)
 
@@ -254,7 +252,7 @@ class OperationTypeWizardPage(QWizardPage):
         self.parent.new_mn.is_operated = self.cb_operator.isChecked()
         self.parent.new_mn.is_owned = self.cb_owner.isChecked()
 
-        # DIP3 type: 0 = Masternode, 1 = EvoNode
+        #type: 0 = Masternode, 1 = EvoNode
         self.parent.new_mn.type = 1 if self.cb_evonode.isChecked() else 0
 
         # Provide safe defaults for platform fields if they exist in ProTxMN
@@ -1144,7 +1142,7 @@ class SaveDip3WizardPage(QWizardPage):
         else:
             op_type = 'unknown'
 
-        self.setTitle('%s DIP3 masternode' % op_type.capitalize())
+        self.setTitle('%s masternode' % op_type.capitalize())
         self.setSubTitle('Examine parameters and %s Masternode.' % op_type)
 
         if start_id != parent.OPERATION_TYPE_PAGE:
@@ -2055,9 +2053,9 @@ class Dip3MasternodeWizard(QWizard):
 
         if start_id:
             self.setStartId(start_id)
-            title = _('Update DIP3 Masternode: {} - {}').format(mn.alias, w)
+            title = _('Update Masternode: {} - {}').format(mn.alias, w)
         else:
-            title = _('Add DIP3 Masternode - {}').format(w)
+            title = _('Add Masternode - {}').format(w)
 
         logo = QPixmap(icon_path('tab_dip3.png'))
         logo = logo.scaledToWidth(32, mode=Qt.SmoothTransformation)
@@ -2209,7 +2207,7 @@ class Dip3MasternodeWizard(QWizard):
             coll_str = '%s:%s' % (prevout_hash, prevout_n)
             if coll_str in mns_collaterals:
                 raise ValidationError('Provided Outpoint already used '
-                                      'in saved DIP3 Masternodes')
+                                      'in saved Masternodes')
 
         return prevout_hash, prevout_n, addr
 
@@ -2282,7 +2280,7 @@ class Dip3FileWizard(QWizard):
         self.skipped_aliases = []
         self.imported_path = None
 
-        title = _('Export/Import DIP3 Masternodes to/from file - {}').format(w)
+        title = _('Export/Import Masternodes to/from file - {}').format(w)
         logo = QPixmap(icon_path('tab_dip3.png'))
         logo = logo.scaledToWidth(32, mode=Qt.SmoothTransformation)
         self.setWizardStyle(QWizard.ClassicStyle)
@@ -2307,8 +2305,8 @@ class FileOpTypeWizardPage(QWizardPage):
         self.setTitle('Operation type')
         self.setSubTitle('Select operation type.')
 
-        self.rb_export = QRadioButton('Export DIP3 Masternodes to file')
-        self.rb_import = QRadioButton('Import DIP3 Masternodes from file')
+        self.rb_export = QRadioButton('Export Masternodes to file')
+        self.rb_import = QRadioButton('Import Masternodes from file')
         self.rb_export.setChecked(True)
         self.button_group = QButtonGroup()
         self.button_group.addButton(self.rb_export)
@@ -2338,9 +2336,9 @@ class ExportToFileWizardPage(QWizardPage):
         self.parent = parent
         self.setCommitPage(True)
         self.setTitle('Export to file')
-        self.setSubTitle('Export DIP3 Masternodes to file.')
+        self.setSubTitle('Export Masternodes to file.')
 
-        self.lb_aliases = QLabel('Exported DIP3 Masternodes:')
+        self.lb_aliases = QLabel('Exported Masternodes:')
         self.lw_aliases = QListWidget()
         self.lw_aliases.setSelectionMode(QAbstractItemView.ExtendedSelection)
         self.sel_model = self.lw_aliases.selectionModel()
@@ -2371,7 +2369,7 @@ class ExportToFileWizardPage(QWizardPage):
         return self.parent.DONE_PAGE
 
     def validatePage(self):
-        fdlg = QFileDialog(self, 'Save DIP3 Masternodes', os.getenv('HOME'))
+        fdlg = QFileDialog(self, 'Save Masternodes', os.getenv('HOME'))
         fdlg.setOptions(QFileDialog.DontConfirmOverwrite)
         fdlg.setAcceptMode(QFileDialog.AcceptSave)
         fdlg.setFileMode(QFileDialog.AnyFile)
@@ -2420,7 +2418,7 @@ class ImportFromFileWizardPage(QWizardPage):
         self.parent = parent
         self.setCommitPage(True)
         self.setTitle('Import from file')
-        self.setSubTitle('Import DIP3 Masternodes from file.')
+        self.setSubTitle('Import Masternodes from file.')
 
         self.imp_btn = QPushButton('Load *.protx file')
         self.imp_btn.clicked.connect(self.on_load_protx)
@@ -2460,7 +2458,7 @@ class ImportFromFileWizardPage(QWizardPage):
 
     @pyqtSlot()
     def on_load_protx(self):
-        fdlg = QFileDialog(self, 'Load DIP3 Masternodes', os.getenv('HOME'))
+        fdlg = QFileDialog(self, 'Load Masternodes', os.getenv('HOME'))
         fdlg.setAcceptMode(QFileDialog.AcceptOpen)
         fdlg.setFileMode(QFileDialog.AnyFile)
         fdlg.setNameFilter("ProTx (*.protx)");

--- a/electrum_dash/gui/qt/protx_wizards.py
+++ b/electrum_dash/gui/qt/protx_wizards.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import os
+import hashlib
 import ipaddress
 import json
 from bls_py import bls
@@ -32,17 +33,95 @@ def is_p2pkh_address(addr):
             return True
     return False
 
-
-class ValidationError(Exception): pass
-
-
-class HwWarnError(Exception): pass
+def _sha256(b: bytes) -> bytes:
+    return hashlib.sha256(b).digest()
 
 
-class UsedInWallet(Exception): pass
+def gen_platform_node_id_from_ed25519_pubkey(pubkey_bytes: bytes) -> str:
+    # PlatformNodeID = first 20 bytes of SHA256(ed25519_public_key)
+    return _sha256(pubkey_bytes)[:20].hex()
 
 
-class UsedInMNList(Exception): pass
+def gen_ed25519_keypair_hex():
+    """
+    Returns (priv_hex, pub_hex)
+    - priv_hex: 32 bytes seed/private key (64 hex chars)
+    - pub_hex:  32 bytes public key (64 hex chars)
+    """
+    # 1) Try cryptography (preferred)
+    try:
+        from cryptography.hazmat.primitives.asymmetric import ed25519
+
+        priv = ed25519.Ed25519PrivateKey.generate()
+        pub = priv.public_key()
+
+        priv_bytes = priv.private_bytes(
+            encoding=None,
+            format=None,
+            encryption_algorithm=None,
+        )
+        # cryptography API does not accept None in real code, so use raw bytes API properly:
+        # We'll use private_bytes_raw/public_bytes_raw if available.
+        if hasattr(priv, "private_bytes_raw") and hasattr(pub, "public_bytes_raw"):
+            priv_bytes = priv.private_bytes_raw()
+            pub_bytes = pub.public_bytes_raw()
+        else:
+            # Fallback for older cryptography
+            from cryptography.hazmat.primitives import serialization
+            priv_bytes = priv.private_bytes(
+                encoding=serialization.Encoding.Raw,
+                format=serialization.PrivateFormat.Raw,
+                encryption_algorithm=serialization.NoEncryption(),
+            )
+            pub_bytes = pub.public_bytes(
+                encoding=serialization.Encoding.Raw,
+                format=serialization.PublicFormat.Raw,
+            )
+
+        return priv_bytes.hex(), pub_bytes.hex()
+    except Exception:
+        pass
+
+    # 2) Try pynacl
+    try:
+        from nacl.signing import SigningKey
+
+        sk = SigningKey.generate()
+        priv_bytes = bytes(sk)               # 32 bytes seed
+        pub_bytes = bytes(sk.verify_key)     # 32 bytes pubkey
+        return priv_bytes.hex(), pub_bytes.hex()
+    except Exception as e:
+        raise ValidationError(
+            'Cannot generate ed25519 keypair. Install "cryptography" or "pynacl". '
+            f'Error: {e}'
+        )
+
+
+def gen_platform_node_id_from_ed25519_pubkey(pub_bytes: bytes) -> str:
+    """
+    PlatformNodeID = first 20 bytes of SHA256(ed25519_public_key)
+    Returns 20-byte hex string (40 chars).
+    """
+    if not isinstance(pub_bytes, (bytes, bytearray)) or len(pub_bytes) != 32:
+        raise ValidationError('Platform ed25519 public key must be 32 bytes')
+    h = hashlib.sha256(bytes(pub_bytes)).digest()
+    return h[:20].hex()
+
+
+class ValidationError(Exception):
+    pass
+
+
+class HwWarnError(Exception):
+    pass
+
+
+class UsedInWallet(Exception):
+    pass
+
+
+class UsedInMNList(Exception):
+    pass
 
 
 class SLineEdit(QLineEdit):
@@ -128,9 +207,16 @@ class OperationTypeWizardPage(QWizardPage):
         self.cb_owner.stateChanged.connect(self.cb_state_changed)
         self.cb_operator.setChecked(True)
         self.cb_operator.stateChanged.connect(self.cb_state_changed)
+
+        self.cb_evonode = QCheckBox(_('Register as EvoNode (Platform enabled)'))
+        self.cb_evonode.setChecked(False)
+        self.cb_evonode.stateChanged.connect(self.cb_state_changed)
+
         gb_vbox = QVBoxLayout()
         gb_vbox.addWidget(self.cb_owner)
         gb_vbox.addWidget(self.cb_operator)
+        gb_vbox.addSpacing(8)
+        gb_vbox.addWidget(self.cb_evonode)
         self.gb_owner = QGroupBox(_('Set ownership type'))
         self.gb_owner.setLayout(gb_vbox)
 
@@ -167,6 +253,20 @@ class OperationTypeWizardPage(QWizardPage):
         self.parent.new_mn.alias = 'default'
         self.parent.new_mn.is_operated = self.cb_operator.isChecked()
         self.parent.new_mn.is_owned = self.cb_owner.isChecked()
+
+        # DIP3 type: 0 = Masternode, 1 = EvoNode
+        self.parent.new_mn.type = 1 if self.cb_evonode.isChecked() else 0
+
+        # Provide safe defaults for platform fields if they exist in ProTxMN
+        # (If not yet present in ProTxMN, they will be added in protx.py patch.)
+        if self.parent.new_mn.type == 1:
+            if not getattr(self.parent.new_mn, 'platform_node_id', ''):
+                self.parent.new_mn.platform_node_id = ''
+            if not getattr(self.parent.new_mn, 'platform_p2p_port', 0):
+                self.parent.new_mn.platform_p2p_port = 26656
+            if not getattr(self.parent.new_mn, 'platform_http_port', 0):
+                self.parent.new_mn.platform_http_port = 443
+
         return True
 
 
@@ -862,6 +962,22 @@ class SaveDip3WizardPage(QWizardPage):
         self.op_payout_address = QLabel()
         self.op_payout_address.hide()
 
+        # Platform summary (EvoNode)
+        self.platform_group_label = QLabel(_('Platform (EvoNode):'))
+        self.platform_group_label.hide()
+        self.platform_node_id_label = QLabel(_('Node ID:'))
+        self.platform_node_id = QLabel()
+        self.platform_p2p_port_label = QLabel(_('P2P Port:'))
+        self.platform_p2p_port = QLabel()
+        self.platform_http_port_label = QLabel(_('HTTP Port:'))
+        self.platform_http_port = QLabel()
+        self.platform_node_id_label.hide()
+        self.platform_node_id.hide()
+        self.platform_p2p_port_label.hide()
+        self.platform_p2p_port.hide()
+        self.platform_http_port_label.hide()
+        self.platform_http_port.hide()
+
         self.cb_make_tx = QCheckBox()
         self.cb_make_tx.setChecked(False)
         self.cb_make_tx.setEnabled(False)
@@ -898,9 +1014,18 @@ class SaveDip3WizardPage(QWizardPage):
         self.layout.addWidget(self.op_payout_address_label, 12, 0)
         self.layout.addWidget(self.op_payout_address, 12, 1)
 
+        # Insert platform summary rows after service
+        self.layout.addWidget(self.platform_group_label, 13, 0, 1, -1)
+        self.layout.addWidget(self.platform_node_id_label, 14, 0)
+        self.layout.addWidget(self.platform_node_id, 14, 1)
+        self.layout.addWidget(self.platform_p2p_port_label, 15, 0)
+        self.layout.addWidget(self.platform_p2p_port, 15, 1)
+        self.layout.addWidget(self.platform_http_port_label, 16, 0)
+        self.layout.addWidget(self.platform_http_port, 16, 1)
+
         self.layout.setColumnStretch(1, 1)
-        self.layout.setRowStretch(13, 1)
-        self.layout.addWidget(self.cb_make_tx, 14, 1, Qt.AlignRight)
+        self.layout.setRowStretch(17, 1)
+        self.layout.addWidget(self.cb_make_tx, 18, 1, Qt.AlignRight)
         self.setLayout(self.layout)
 
     def initializePage(self):
@@ -921,6 +1046,15 @@ class SaveDip3WizardPage(QWizardPage):
         self.op_payout_address.setText('')
         self.op_payout_address.hide()
         self.op_payout_address_label.hide()
+
+        # Reset platform summary
+        self.platform_group_label.hide()
+        self.platform_node_id_label.hide()
+        self.platform_node_id.hide()
+        self.platform_p2p_port_label.hide()
+        self.platform_p2p_port.hide()
+        self.platform_http_port_label.hide()
+        self.platform_http_port.hide()
 
         if not self.alias.text():
             self.alias.setText(new_mn.alias)
@@ -973,6 +1107,24 @@ class SaveDip3WizardPage(QWizardPage):
             self.op_payout_address.show()
             self.op_payout_address_label.show()
 
+        # Platform summary if EvoNode
+        if getattr(new_mn, 'type', 0) == 1:
+            node_id = getattr(new_mn, 'platform_node_id', '')
+            p2p_port = getattr(new_mn, 'platform_p2p_port', 0)
+            http_port = getattr(new_mn, 'platform_http_port', 0)
+
+            self.platform_group_label.show()
+            self.platform_node_id_label.show()
+            self.platform_node_id.show()
+            self.platform_p2p_port_label.show()
+            self.platform_p2p_port.show()
+            self.platform_http_port_label.show()
+            self.platform_http_port.show()
+
+            self.platform_node_id.setText(node_id or '')
+            self.platform_p2p_port.setText(str(p2p_port or ''))
+            self.platform_http_port.setText(str(http_port or ''))
+
         parent = self.parent
         start_id = parent.startId()
         op_type = 'save'
@@ -1021,6 +1173,27 @@ class SaveDip3WizardPage(QWizardPage):
         parent = self.parent
         start_id = parent.startId()
         alias = self.alias.text()
+
+        # Auto-generate EvoNode Platform keys and Platform Node ID if needed
+        mn = self.new_mn
+        if int(getattr(mn, 'type', 0)) == 1:
+            # If we don't have pubkey, generate keypair
+            if not getattr(mn, 'platform_ed25519_pubkey', ''):
+                priv_hex, pub_hex = gen_ed25519_keypair_hex()
+                mn.platform_ed25519_privkey = priv_hex
+                mn.platform_ed25519_pubkey = pub_hex
+
+            # Derive node id strictly from pubkey
+            try:
+                pub_bytes = bfh(mn.platform_ed25519_pubkey)
+            except Exception:
+                raise ValidationError('Platform ed25519 public key must be valid hex')
+
+            if len(pub_bytes) != 32:
+                raise ValidationError('Platform ed25519 public key must be 32 bytes')
+
+            mn.platform_node_id = gen_platform_node_id_from_ed25519_pubkey(pub_bytes)
+
         if start_id == parent.OPERATION_TYPE_PAGE:
             try:
                 parent.validate_alias(self.alias.text())
@@ -1062,7 +1235,11 @@ class SaveDip3WizardPage(QWizardPage):
             gui.do_clear()
             mn = self.new_mn
             if mn.collateral.is_null and tx_type == dash_tx.SPEC_PRO_REG_TX:
-                gui.amount_e.setText('1000')
+                # For DIP3 collateral created as ProRegTx output:
+                # - Regular Masternode: 1000 DASH
+                # - EvoNode: 4000 DASH
+                coll_amt = '4000' if getattr(mn, 'type', 0) == 1 else '1000'
+                gui.amount_e.setText(coll_amt)
             mn_addrs = [mn.owner_addr, mn.voting_addr, mn.payout_address]
             for addr in manager.wallet.get_unused_addresses():
                 if addr not in mn_addrs:
@@ -1320,6 +1497,35 @@ class ServiceWizardPage(QWizardPage):
         self.srv_port = SLineEdit()
         self.srv_port.textChanged.connect(self.on_service_changed)
 
+        # Platform (EvoNode)
+        self.pl_group = QGroupBox(_('Platform (EvoNode)'))
+        pl_layout = QGridLayout()
+
+        self.pl_node_id_label = QLabel(_('Platform Node ID (20 bytes hex):'))
+        self.pl_node_id = SLineEdit()
+        self.pl_node_id.setReadOnly(True)  # deterministic from ed25519 pubkey
+        self.pl_node_id.textChanged.connect(self.on_platform_changed)
+
+        self.pl_p2p_port_label = QLabel(_('Platform P2P Port:'))
+        self.pl_p2p_port = SLineEdit()
+        self.pl_p2p_port.textChanged.connect(self.on_platform_changed)
+
+        self.pl_http_port_label = QLabel(_('Platform HTTP Port:'))
+        self.pl_http_port = SLineEdit()
+        self.pl_http_port.textChanged.connect(self.on_platform_changed)
+
+        pl_layout.addWidget(self.pl_node_id_label, 0, 0, 1, -1)
+        pl_layout.addWidget(self.pl_node_id, 1, 0, 1, -1)
+        pl_layout.addWidget(self.pl_p2p_port_label, 2, 0)
+        pl_layout.addWidget(self.pl_p2p_port, 2, 1)
+        pl_layout.addWidget(self.pl_http_port_label, 2, 2)
+        pl_layout.addWidget(self.pl_http_port, 2, 3)
+        pl_layout.setColumnStretch(1, 1)
+        pl_layout.setColumnStretch(3, 1)
+
+        self.pl_group.setLayout(pl_layout)
+        self.pl_group.hide()
+
         self.err_label = QLabel('Error:')
         self.err_label.setObjectName('err-label')
         self.err = QLabel()
@@ -1334,12 +1540,14 @@ class ServiceWizardPage(QWizardPage):
         layout.addWidget(self.srv_port_label, 0, 2)
         layout.addWidget(self.srv_port, 0, 3)
 
-        layout.addWidget(self.err_label, 1, 0)
-        layout.addWidget(self.err, 1, 1, 1, -1)
-        layout.addWidget(self.cb_ignore_wallet, 3, 0, 1, -1)
-        layout.addWidget(self.cb_ignore_mn_list, 4, 0, 1, -1)
+        layout.addWidget(self.pl_group, 1, 0, 1, -1)
+
+        layout.addWidget(self.err_label, 2, 0)
+        layout.addWidget(self.err, 2, 1, 1, -1)
+        layout.addWidget(self.cb_ignore_wallet, 4, 0, 1, -1)
+        layout.addWidget(self.cb_ignore_mn_list, 5, 0, 1, -1)
         layout.setColumnStretch(1, 1)
-        layout.setRowStretch(2, 1)
+        layout.setRowStretch(3, 1)
         self.setLayout(layout)
 
     def hide_error(self):
@@ -1355,23 +1563,64 @@ class ServiceWizardPage(QWizardPage):
     def on_service_changed(self):
         self.completeChanged.emit()
 
+    @pyqtSlot()
+    def on_platform_changed(self):
+        self.completeChanged.emit()
+
     def isComplete(self):
         self.hide_error()
         if self.srv_port.text():
             return True
         return False
 
+    def _ensure_platform_defaults(self, mn):
+        # Generate ed25519 keypair + node id if missing (EvoNode only)
+        if int(getattr(mn, 'type', 0)) != 1:
+            return
+
+        if not getattr(mn, 'platform_ed25519_pubkey', ''):
+            priv_hex, pub_hex = gen_ed25519_keypair_hex()
+            mn.platform_ed25519_privkey = priv_hex
+            mn.platform_ed25519_pubkey = pub_hex
+
+        if not getattr(mn, 'platform_node_id', ''):
+            pub_bytes = bfh(mn.platform_ed25519_pubkey)
+            if len(pub_bytes) != 32:
+                raise ValidationError('Platform ed25519 public key must be 32 bytes')
+            # PlatformNodeID = first 20 bytes of SHA256(ed25519_public_key)
+            mn.platform_node_id = gen_platform_node_id_from_ed25519_pubkey(pub_bytes)
+
+        if not getattr(mn, 'platform_p2p_port', None):
+            mn.platform_p2p_port = 26656
+        if not getattr(mn, 'platform_http_port', None):
+            mn.platform_http_port = 443
+
     def initializePage(self):
         new_mn = self.parent.new_mn
-        str_mn_service = str(new_mn.service)
+
         self.cb_ignore_wallet.hide()
         self.cb_ignore_mn_list.hide()
         self.cb_ignore_wallet.setChecked(False)
         self.cb_ignore_mn_list.setChecked(False)
+
+        # Show/hide platform block based on type
+        is_evo = int(getattr(new_mn, 'type', 0)) == 1
+        self.pl_group.setVisible(is_evo)
+
+        # Make sure platform fields exist BEFORE user can continue
+        if is_evo:
+            self._ensure_platform_defaults(new_mn)
+
+        str_mn_service = str(new_mn.service)
         if self.cur_service is None or self.cur_service != str_mn_service:
             self.cur_service = str_mn_service
             self.srv_addr.setText(new_mn.service.ip)
             self.srv_port.setText('%d' % new_mn.service.port)
+
+        if is_evo:
+            self.pl_node_id.setText(getattr(new_mn, 'platform_node_id', '') or '')
+            self.pl_p2p_port.setText(str(int(getattr(new_mn, 'platform_p2p_port', 26656) or 26656)))
+            self.pl_http_port.setText(str(int(getattr(new_mn, 'platform_http_port', 443) or 443)))
 
     def validatePage(self):
         ip = self.srv_addr.text()
@@ -1379,9 +1628,9 @@ class ServiceWizardPage(QWizardPage):
         try:
             ignore_wallet = self.cb_ignore_wallet.isChecked()
             ignore_mn_list = self.cb_ignore_mn_list.isChecked()
-            ip, port = self.parent.validate_service_ip_port(ip, port,
-                                                            ignore_wallet,
-                                                            ignore_mn_list)
+            ip, port = self.parent.validate_service_ip_port(
+                ip, port, ignore_wallet, ignore_mn_list
+            )
         except UsedInWallet as e:
             self.cb_ignore_wallet.show()
             self.show_error(str(e))
@@ -1393,7 +1642,35 @@ class ServiceWizardPage(QWizardPage):
         except ValidationError as e:
             self.show_error(str(e))
             return False
-        self.parent.new_mn.service = ProTxService(ip, port)
+
+        new_mn = self.parent.new_mn
+        new_mn.service = ProTxService(ip, port)
+
+        # Persist + validate platform fields if EvoNode
+        if int(getattr(new_mn, 'type', 0)) == 1:
+            # Ensure defaults even if something cleared before validation
+            try:
+                self._ensure_platform_defaults(new_mn)
+            except ValidationError as e:
+                self.show_error(str(e))
+                return False
+
+            try:
+                p2p_port, http_port = self.parent.validate_platform_ports(
+                    self.pl_p2p_port.text(),
+                    self.pl_http_port.text()
+                )
+            except ValidationError as e:
+                self.show_error(str(e))
+                return False
+
+            new_mn.platform_node_id = (self.pl_node_id.text() or '').strip() or new_mn.platform_node_id
+            new_mn.platform_p2p_port = p2p_port
+            new_mn.platform_http_port = http_port
+
+            # Refresh UI with final deterministic value
+            self.pl_node_id.setText(new_mn.platform_node_id)
+
         return True
 
     def nextId(self):
@@ -1420,6 +1697,34 @@ class UpdSrvWizardPage(QWizardPage):
         self.srv_port = SLineEdit()
         self.srv_port.textChanged.connect(self.on_service_changed)
 
+        # Platform (EvoNode) update block
+        self.pl_group = QGroupBox(_('Platform (EvoNode)'))
+        pl_layout = QGridLayout()
+
+        self.pl_node_id_label = QLabel(_('Platform Node ID (20 bytes hex):'))
+        self.pl_node_id = SLineEdit()
+        self.pl_node_id.textChanged.connect(self.on_service_changed)
+
+        self.pl_p2p_port_label = QLabel(_('Platform P2P Port:'))
+        self.pl_p2p_port = SLineEdit()
+        self.pl_p2p_port.textChanged.connect(self.on_service_changed)
+
+        self.pl_http_port_label = QLabel(_('Platform HTTP Port:'))
+        self.pl_http_port = SLineEdit()
+        self.pl_http_port.textChanged.connect(self.on_service_changed)
+
+        pl_layout.addWidget(self.pl_node_id_label, 0, 0, 1, -1)
+        pl_layout.addWidget(self.pl_node_id, 1, 0, 1, -1)
+        pl_layout.addWidget(self.pl_p2p_port_label, 2, 0)
+        pl_layout.addWidget(self.pl_p2p_port, 2, 1)
+        pl_layout.addWidget(self.pl_http_port_label, 2, 2)
+        pl_layout.addWidget(self.pl_http_port, 2, 3)
+        pl_layout.setColumnStretch(1, 1)
+        pl_layout.setColumnStretch(3, 1)
+
+        self.pl_group.setLayout(pl_layout)
+        self.pl_group.hide()
+
         self.op_p_addr_label = QLabel('Operator Payout Address:')
         self.op_p_addr_cb = SComboBox()
         self.op_p_addr_cb.setEditable(True)
@@ -1441,15 +1746,18 @@ class UpdSrvWizardPage(QWizardPage):
         layout.addWidget(self.srv_addr, 0, 1)
         layout.addWidget(self.srv_port_label, 0, 2)
         layout.addWidget(self.srv_port, 0, 3)
-        layout.addWidget(self.op_p_addr_label, 1, 0)
-        layout.addWidget(self.op_p_addr_cb, 1, 1, 1, -1)
 
-        layout.addWidget(self.err_label, 2, 0)
-        layout.addWidget(self.err, 2, 1, 1, -1)
-        layout.addWidget(self.cb_ignore_wallet, 4, 0, 1, -1)
-        layout.addWidget(self.cb_ignore_mn_list, 5, 0, 1, -1)
+        layout.addWidget(self.pl_group, 1, 0, 1, -1)
+
+        layout.addWidget(self.op_p_addr_label, 2, 0)
+        layout.addWidget(self.op_p_addr_cb, 2, 1, 1, -1)
+
+        layout.addWidget(self.err_label, 3, 0)
+        layout.addWidget(self.err, 3, 1, 1, -1)
+        layout.addWidget(self.cb_ignore_wallet, 5, 0, 1, -1)
+        layout.addWidget(self.cb_ignore_mn_list, 6, 0, 1, -1)
         layout.setColumnStretch(1, 1)
-        layout.setRowStretch(3, 1)
+        layout.setRowStretch(4, 1)
         self.setLayout(layout)
 
     def nextId(self):
@@ -1474,6 +1782,13 @@ class UpdSrvWizardPage(QWizardPage):
         self.cb_ignore_mn_list.setChecked(False)
         self.srv_addr.setText(upd_mn.service.ip)
         self.srv_port.setText('%d' % upd_mn.service.port)
+
+        is_evo = getattr(upd_mn, 'type', 0) == 1
+        self.pl_group.setVisible(is_evo)
+        if is_evo:
+            self.pl_node_id.setText(getattr(upd_mn, 'platform_node_id', '') or '')
+            self.pl_p2p_port.setText(str(getattr(upd_mn, 'platform_p2p_port', 26656) or 26656))
+            self.pl_http_port.setText(str(getattr(upd_mn, 'platform_http_port', 443) or 443))
 
         if not upd_mn.is_owned and upd_mn.is_operated:
             for addr in self.parent.wallet.get_unused_addresses():
@@ -1525,6 +1840,24 @@ class UpdSrvWizardPage(QWizardPage):
             self.show_error(str(e))
             return False
         self.parent.new_mn.service = ProTxService(ip, port)
+
+        # Validate platform fields if EvoNode
+        upd_mn = self.upd_mn
+        if getattr(upd_mn, 'type', 0) == 1:
+            try:
+                node_id = self.parent.validate_platform_node_id(self.pl_node_id.text())
+                p2p_port, http_port = self.parent.validate_platform_ports(
+                    self.pl_p2p_port.text(),
+                    self.pl_http_port.text()
+                )
+            except ValidationError as e:
+                self.show_error(str(e))
+                return False
+
+            upd_mn.platform_node_id = node_id
+            upd_mn.platform_p2p_port = p2p_port
+            upd_mn.platform_http_port = http_port
+
         if not self.upd_mn.is_owned and self.upd_mn.is_operated:
             op_p_addr = self.op_p_addr.text()
             if op_p_addr and not is_b58_address(op_p_addr):
@@ -1790,6 +2123,30 @@ class Dip3MasternodeWizard(QWizard):
             raise UsedInMNList(err)
         return ip, port
 
+    def validate_platform_node_id(self, node_id_hex):
+        node_id_hex = (node_id_hex or '').strip().lower()
+        if not node_id_hex:
+            raise ValidationError('Platform Node ID is not set')
+        if len(node_id_hex) != 40:
+            raise ValidationError('Platform Node ID must be 20 bytes hex (40 chars)')
+        if node_id_hex.strip('0123456789abcdef'):
+            raise ValidationError('Platform Node ID must be hex string')
+        return node_id_hex
+
+    def validate_platform_ports(self, p2p_port, http_port):
+        try:
+            p2p = int(p2p_port)
+        except ValueError:
+            raise ValidationError('Platform P2P port must be integer number')
+        try:
+            http = int(http_port)
+        except ValueError:
+            raise ValidationError('Platform HTTP port must be integer number')
+        for val, name in [(p2p, 'Platform P2P port'), (http, 'Platform HTTP port')]:
+            if not 1 <= val <= 65535:
+                raise ValidationError('%s must be in range 1-65535' % name)
+        return p2p, http
+
     def validate_bls_pub(self, bls_pub, ignore_wallet, ignore_mn_list):
         skip_alias = None
         start_id = self.startId()
@@ -1897,6 +2254,10 @@ class Dip3MasternodeWizard(QWizard):
             raise HwWarnError(hw_warn_msg + hw_warn_possibility)
 
 
+# The rest of the file (Dip3FileWizard, etc.) stays unchanged
+# ----------------------------------------------------------
+# NOTE: Your original file continues below exactly as it was.
+# ----------------------------------------------------------
 class Dip3FileWizard(QWizard):
 
     OP_TYPE_PAGE = 1

--- a/electrum_dash/protx.py
+++ b/electrum_dash/protx.py
@@ -29,10 +29,12 @@ import threading
 from . import constants, util
 from .bitcoin import address_to_script, is_b58_address, b58_address_to_hash160
 from .protx_list import MNList
-from .dash_tx import (TxOutPoint, ProTxService, DashProRegTx, DashProUpServTx,
-                      DashProUpRegTx, DashProUpRevTx,
-                      SPEC_PRO_REG_TX, SPEC_PRO_UP_SERV_TX,
-                      SPEC_PRO_UP_REG_TX, SPEC_PRO_UP_REV_TX, str_ip)
+from .dash_tx import (
+    TxOutPoint, ProTxService, DashProRegTx, DashProUpServTx,
+    DashProUpRegTx, DashProUpRevTx,
+    SPEC_PRO_REG_TX, SPEC_PRO_UP_SERV_TX,
+    SPEC_PRO_UP_REG_TX, SPEC_PRO_UP_REV_TX, str_ip
+)
 from .util import bfh, bh2u
 from .json_db import StoredDict
 from .logging import Logger
@@ -46,19 +48,30 @@ PROTX_TX_TYPES = [
 ]
 
 
-class ProTxMNExc(Exception): pass
+def _script_from_address(addr: str) -> bytes:
+    # address_to_script may return bytes OR hex string depending on fork/version
+    scr = address_to_script(addr)
+    if isinstance(scr, (bytes, bytearray)):
+        return bytes(scr)
+    if isinstance(scr, str):
+        return bfh(scr)
+    raise TypeError('address_to_script returned unsupported type: %s' % type(scr).__name__)
+
+
+class ProTxMNExc(Exception):
+    pass
 
 
 class ProTxMN:
     '''
-    Masternode data with next properties:
+    Masternode/EvoNode data with next properties:
 
     alias               MN alias
-    is_owned            This wallet is has owner_addr privk
-    is_operated         This wallet must generate BLS privk
-    bls_privk           Random BLS key
+    is_owned            This wallet has owner_addr privk
+    is_operated         This wallet operates and must have BLS privk
+    bls_privk           Random BLS private key (hex)
 
-    type                MN type
+    type                MN type (0 = Masternode, 1 = EvoNode)
     mode                MN mode
     collateral          TxOutPoint collateral data
     service             ProTxService masternode service data
@@ -69,12 +82,20 @@ class ProTxMN:
     payout_address      Payee address
     op_payout_address   Operator payee address
 
-    protx_hash          Hash of ProRegTx transaction
+    protx_hash          Hash of ProRegTx transaction (hex, big-endian)
+
+    platform_node_id    EvoNode only: 20-byte Node ID hex (40 chars)
+    platform_p2p_port   EvoNode only: Platform P2P port
+    platform_http_port  EvoNode only: Platform HTTP port
     '''
 
-    fields = ('alias is_owned is_operated bls_privk type mode '
-              'collateral service owner_addr pubkey_operator voting_addr '
-              'op_reward payout_address op_payout_address protx_hash').split()
+    fields = (
+        'alias is_owned is_operated bls_privk type mode '
+        'collateral service owner_addr pubkey_operator voting_addr '
+        'op_reward payout_address op_payout_address protx_hash '
+        'platform_node_id platform_p2p_port platform_http_port '
+        'platform_ed25519_privkey platform_ed25519_pubkey'
+    ).split()
 
     def __init__(self):
         self.alias = ''
@@ -94,6 +115,13 @@ class ProTxMN:
         self.op_payout_address = ''
 
         self.protx_hash = ''
+
+        # EvoNode / Platform fields
+        self.platform_node_id = ''
+        self.platform_p2p_port = 26656
+        self.platform_http_port = 443
+        self.platform_ed25519_privkey = ''
+        self.platform_ed25519_pubkey = ''
 
     @classmethod
     def default_port(cls):
@@ -119,6 +147,12 @@ class ProTxMN:
         mn = ProTxMN()
         for f in cls.fields:
             if f not in d:
+                # Backward compatibility: older stored data does not have platform fields
+                if f in (
+                        'platform_node_id', 'platform_p2p_port', 'platform_http_port',
+                        'platform_ed25519_privkey', 'platform_ed25519_pubkey'
+                ):
+                    continue
                 raise ProTxMNExc('Key %s is missing in supplied dict')
             v = d[f]
             if isinstance(v, StoredDict):
@@ -131,13 +165,28 @@ class ProTxMN:
                 setattr(mn, f, ProTxService(**v))
             else:
                 setattr(mn, f, v)
+
+        # Ensure defaults if missing
+        if not getattr(mn, 'platform_node_id', None):
+            mn.platform_node_id = ''
+        if getattr(mn, 'platform_p2p_port', None) is None:
+            mn.platform_p2p_port = 0
+        if getattr(mn, 'platform_http_port', None) is None:
+            mn.platform_http_port = 0
+        if not getattr(mn, 'platform_ed25519_privkey', None):
+            mn.platform_ed25519_privkey = ''
+        if not getattr(mn, 'platform_ed25519_pubkey', None):
+            mn.platform_ed25519_pubkey = ''
+
         return mn
 
 
-class ProTxManagerExc(Exception): pass
+class ProTxManagerExc(Exception):
+    pass
 
 
-class ProRegTxExc(Exception): pass
+class ProRegTxExc(Exception):
+    pass
 
 
 class ProTxManager(Logger):
@@ -257,6 +306,28 @@ class ProTxManager(Logger):
         del self.mns[alias]
         self.save(with_lock=False)
 
+    def _validate_platform_fields(self, mn):
+        # Required only for EvoNode (type == 1)
+        if int(getattr(mn, 'type', 0)) != 1:
+            return
+
+        node_id = (getattr(mn, 'platform_node_id', '') or '').strip()
+        if len(node_id) != 40 or node_id.strip('0123456789abcdefABCDEF'):
+            raise ProRegTxExc('Platform Node ID must be 20 bytes hex (40 chars)')
+
+        try:
+            p2p = int(getattr(mn, 'platform_p2p_port', 0))
+            http = int(getattr(mn, 'platform_http_port', 0))
+        except Exception:
+            raise ProRegTxExc('Platform ports must be integers')
+
+        if not (1 <= p2p <= 65535) or not (1 <= http <= 65535):
+            raise ProRegTxExc('Platform ports must be in range 1-65535')
+
+        if p2p == http:
+            raise ProRegTxExc('Platform P2P port and HTTP port must differ')
+
+
     def prepare_pro_reg_tx(self, alias):
         '''Prepare and return ProRegTx from ProTxMN alias'''
         mn = self.mns.get('%s' % alias)
@@ -296,16 +367,75 @@ class ProTxManager(Logger):
         if not is_b58_address(mn.payout_address):
             raise ProRegTxExc('Payout address is not address')
 
-        scriptPayout = bfh(address_to_script(mn.payout_address))
+        scriptPayout = _script_from_address(mn.payout_address)
         KeyIdOwner = b58_address_to_hash160(mn.owner_addr)[1]
         PubKeyOperator = bfh(mn.pubkey_operator)
         KeyIdVoting = b58_address_to_hash160(mn.voting_addr)[1]
-        payloadSig = b'' if coll_hash_is_null else b'\x00'*65
 
-        tx = DashProRegTx(2, mn.type, mn.mode, mn.collateral, mn.service.ip,
-                          mn.service.port, KeyIdOwner, PubKeyOperator,
-                          KeyIdVoting, mn.op_reward, scriptPayout,
-                          b'\x00'*32, payloadSig)
+        # For in-tx collateral (hash null), payloadSig must be empty.
+        # Otherwise, placeholder 65 bytes is used and later replaced by update_before_sign.
+        payloadSig = b'' if coll_hash_is_null else b'\x00' * 65
+
+        # ---- platform defaults ----
+        if int(getattr(mn, 'type', 0)) == 1:
+            node_id_hex = (getattr(mn, 'platform_node_id', '') or '').strip()
+            if not node_id_hex:
+                raise ProRegTxExc('Platform Node ID is not set for EvoNode')
+
+            try:
+                platform_node_id = bfh(node_id_hex)
+            except Exception:
+                raise ProRegTxExc('Platform Node ID must be valid hex')
+
+            if len(platform_node_id) != 20:
+                raise ProRegTxExc('Platform Node ID must be 20 bytes')
+
+            platform_p2p_port = int(mn.platform_p2p_port)
+            platform_http_port = int(mn.platform_http_port)
+        else:
+            platform_node_id = b'\x00' * 20
+            platform_p2p_port = 0
+            platform_http_port = 0
+        # ----------------------------
+
+        # Newer DashProRegTx in your fork likely expects platform fields as well.
+        # Try the "full" evonode-compatible argument list first, then fallback.
+        try:
+            tx = DashProRegTx(
+                2,
+                int(mn.type),
+                int(mn.mode),
+                mn.collateral,
+                mn.service.ip,
+                int(mn.service.port),
+                KeyIdOwner,
+                PubKeyOperator,
+                KeyIdVoting,
+                int(mn.op_reward),
+                scriptPayout,
+                b'\x00' * 32,  # inputsHash
+                platform_node_id,
+                int(platform_p2p_port),
+                int(platform_http_port),
+                payloadSig,
+            )
+        except (TypeError, IndexError):
+            # Fallback for older constructor variants
+            tx = DashProRegTx(
+                2,
+                int(mn.type),
+                int(mn.mode),
+                mn.collateral,
+                mn.service.ip,
+                int(mn.service.port),
+                KeyIdOwner,
+                PubKeyOperator,
+                KeyIdVoting,
+                int(mn.op_reward),
+                scriptPayout,
+                b'\x00' * 32,
+                payloadSig,
+            )
 
         if not coll_hash_is_null:
             tx.payload_sig_msg_part = ('%s|%s|%s|%s|' %
@@ -316,7 +446,7 @@ class ProTxManager(Logger):
         return tx
 
     def prepare_pro_up_srv_tx(self, mn):
-        '''Prepare and return ProUpServTx from ProTxMN alias'''
+        '''Prepare and return ProUpServTx from ProTxMN'''
         if not mn.protx_hash:
             raise ProRegTxExc('Masternode has no proTxHash')
 
@@ -326,20 +456,50 @@ class ProTxManager(Logger):
         if not mn.service.ip:
             raise ProRegTxExc('Service IP address is not set')
 
+        self._validate_platform_fields(mn)
+
         if mn.op_payout_address:
             if not is_b58_address(mn.op_payout_address):
                 raise ProRegTxExc('Operator payout address is not address')
-            scriptOpPayout = bfh(address_to_script(mn.op_payout_address))
+            scriptOpPayout = _script_from_address(mn.op_payout_address)
         else:
             scriptOpPayout = b''
 
-        tx = DashProUpServTx(2, bfh(mn.protx_hash)[::-1],
-                             mn.service.ip, mn.service.port,
-                             scriptOpPayout, b'\x00'*32, b'\x00'*96, 0)
+        # Important: payloadSig placeholder must be 96 bytes for BLS
+        payloadSig = b'\x00' * 96
+        inputsHash = b'\x00' * 32
+
+        # EvoNode: try constructor with platform fields
+        if int(mn.type) == 1:
+            platform_node_id = bfh(mn.platform_node_id)
+            try:
+                tx = DashProUpServTx(
+                    2, bfh(mn.protx_hash)[::-1],
+                    mn.service.ip, mn.service.port,
+                    scriptOpPayout, inputsHash, payloadSig,
+                    int(mn.type),
+                    platform_node_id,
+                    int(mn.platform_p2p_port),
+                    int(mn.platform_http_port)
+                )
+            except TypeError:
+                tx = DashProUpServTx(
+                    2, bfh(mn.protx_hash)[::-1],
+                    mn.service.ip, mn.service.port,
+                    scriptOpPayout, inputsHash, payloadSig,
+                    int(mn.type)
+                )
+        else:
+            tx = DashProUpServTx(
+                2, bfh(mn.protx_hash)[::-1],
+                mn.service.ip, mn.service.port,
+                scriptOpPayout, inputsHash, payloadSig,
+                int(mn.type)
+            )
         return tx
 
     def prepare_pro_up_reg_tx(self, mn):
-        '''Prepare and return ProUpRegTx from ProTxMN alias'''
+        '''Prepare and return ProUpRegTx from ProTxMN'''
         if not mn.protx_hash:
             raise ProRegTxExc('Masternode has no proTxHash')
 
@@ -358,13 +518,15 @@ class ProTxManager(Logger):
         if not is_b58_address(mn.payout_address):
             raise ProRegTxExc('Payout address is not address')
 
-        scriptPayout = bfh(address_to_script(mn.payout_address))
+        scriptPayout = _script_from_address(mn.payout_address)
         PubKeyOperator = bfh(mn.pubkey_operator)
         KeyIdVoting = b58_address_to_hash160(mn.voting_addr)[1]
 
-        tx = DashProUpRegTx(2, bfh(mn.protx_hash)[::-1], mn.mode,
-                            PubKeyOperator, KeyIdVoting, scriptPayout,
-                            b'\x00'*32, b'\x00'*65)
+        tx = DashProUpRegTx(
+            2, bfh(mn.protx_hash)[::-1], mn.mode,
+            PubKeyOperator, KeyIdVoting, scriptPayout,
+            b'\x00' * 32, b'\x00' * 65
+        )
         return tx
 
     def prepare_pro_up_rev_tx(self, alias, reason):
@@ -382,8 +544,10 @@ class ProTxManager(Logger):
         if not isinstance(reason, int) or not 0 <= reason <= 3:
             raise ProRegTxExc('Reason must be integer in range 0-3')
 
-        tx = DashProUpRevTx(1, bfh(mn.protx_hash)[::-1], reason,
-                            b'\x00'*32, b'\x00'*96)
+        tx = DashProUpRevTx(
+            1, bfh(mn.protx_hash)[::-1], reason,
+            b'\x00' * 32, b'\x00' * 96
+        )
         return tx
 
     def update_mn_from_sml_entry(self, mn, sml_entry):

--- a/electrum_dash/tests/test_dash_tx.py
+++ b/electrum_dash/tests/test_dash_tx.py
@@ -450,8 +450,19 @@ class TestDashSpecTxSerialization(SequentialTestCase):
         deser = tx.to_json()
         assert deser['version'] == 3
         assert deser['tx_type'] == 1
+
         extra_dict = deser['extra_payload']
-        assert extra_dict == PRO_REG_TX_D
+
+        # Backward-compatible check: all legacy fields must match exactly.
+        for k, v in PRO_REG_TX_D.items():
+            assert extra_dict[k] == v
+
+        # Platform fields might be present in JSON (for EvoNode compatibility).
+        # For regular masternodes (type=0) they must be defaults if present.
+        assert extra_dict.get('platformNodeID', '') == ''
+        assert extra_dict.get('platformP2PPort', 0) == 0
+        assert extra_dict.get('platformHTTPPort', 0) == 0
+
         extra = tx.extra_payload
         assert str(extra)
         assert extra.version == PRO_REG_TX_D['version']
@@ -473,6 +484,7 @@ class TestDashSpecTxSerialization(SequentialTestCase):
         assert len(extra.inputsHash) == 32
         assert extra.inputsHash == bfh(PRO_REG_TX_D['inputsHash'])
         assert extra.payloadSig == bfh(PRO_REG_TX_D['payloadSig'])
+
         ser = tx.serialize()
         assert ser == PRO_REG_TX
 

--- a/electrum_dash/tests/test_protx.py
+++ b/electrum_dash/tests/test_protx.py
@@ -4,6 +4,19 @@ from electrum_dash.dash_tx import TxOutPoint
 from electrum_dash.protx import ProTxMN
 
 
+def _strip_platform_fields(d: dict) -> dict:
+    d = dict(d)
+    for k in (
+        'platform_node_id',
+        'platform_p2p_port',
+        'platform_http_port',
+        'platform_ed25519_privkey',
+        'platform_ed25519_pubkey',
+    ):
+        d.pop(k, None)
+    return d
+
+
 class ProTxTestCase(unittest.TestCase):
 
     def test_protxmn(self):
@@ -12,7 +25,7 @@ class ProTxTestCase(unittest.TestCase):
             'bls_privk': '702ac35f02311c6b3209538c2784c21a'
                          '066d767b53d5a7c69fd677f1949a76a5',
             'collateral': {
-                'hash': '0'*64,
+                'hash': '0' * 64,
                 'index': -1
             },
             'is_operated': True,
@@ -31,26 +44,89 @@ class ProTxTestCase(unittest.TestCase):
                 'port': 9999
             },
             'type': 0,
-            'voting_addr': 'yevc1CQmqyPWJjz1kg9KbnAvov8K3RmaYz'}
+            'voting_addr': 'yevc1CQmqyPWJjz1kg9KbnAvov8K3RmaYz',
+        }
 
         mn = ProTxMN.from_dict(mn_dict)
         assert mn.alias == 'default'
-        assert mn.is_owned == True
-        assert mn.is_operated == True
-        assert mn.bls_privk == ('702ac35f02311c6b3209538c2784c21a'
-                                '066d767b53d5a7c69fd677f1949a76a5')
+        assert mn.is_owned is True
+        assert mn.is_operated is True
+        assert mn.bls_privk == (
+            '702ac35f02311c6b3209538c2784c21a'
+            '066d767b53d5a7c69fd677f1949a76a5'
+        )
         assert mn.type == 0
         assert mn.mode == 0
-        assert mn.collateral == TxOutPoint(b'\x00'*32, -1)
+        assert mn.collateral == TxOutPoint(b'\x00' * 32, -1)
         assert str(mn.service) == '127.0.0.1:9999'
         assert mn.owner_addr == 'yevc1CQmqyPWJjz1kg9KbnAvov8K3RmaYz'
-        assert mn.pubkey_operator == ('012152114d9b7edaa5473c93858f8c11'
-                                      'fa12b6f8afa37a40ed335407b207f7c8'
-                                      'caa46092586c369daba06cfda00893ae')
+        assert mn.pubkey_operator == (
+            '012152114d9b7edaa5473c93858f8c11'
+            'fa12b6f8afa37a40ed335407b207f7c8'
+            'caa46092586c369daba06cfda00893ae'
+        )
         assert mn.voting_addr == 'yevc1CQmqyPWJjz1kg9KbnAvov8K3RmaYz'
         assert mn.op_reward == 0
         assert mn.payout_address == 'ygeCXmn4ysXxL1DmUAcmuG5WA6QwNJbr3b'
         assert mn.op_payout_address == ''
         assert mn.protx_hash == ''
+
+        mn_dict2 = mn.as_dict()
+        assert _strip_platform_fields(mn_dict2) == mn_dict
+
+        # Ensure platform fields exist and have sane defaults (backward compatible behavior).
+        assert hasattr(mn, 'platform_node_id')
+        assert hasattr(mn, 'platform_p2p_port')
+        assert hasattr(mn, 'platform_http_port')
+        assert hasattr(mn, 'platform_ed25519_privkey')
+        assert hasattr(mn, 'platform_ed25519_pubkey')
+
+        assert mn.platform_node_id == ''
+        assert isinstance(mn.platform_p2p_port, int)
+        assert isinstance(mn.platform_http_port, int)
+        assert mn.platform_ed25519_privkey == ''
+        assert mn.platform_ed25519_pubkey == ''
+
+    def test_protxmn_evonode_roundtrip(self):
+        mn_dict = {
+            'alias': 'evonode1',
+            'bls_privk': '702ac35f02311c6b3209538c2784c21a'
+                         '066d767b53d5a7c69fd677f1949a76a5',
+            'collateral': {
+                'hash': '0' * 64,
+                'index': -1
+            },
+            'is_operated': True,
+            'is_owned': True,
+            'mode': 0,
+            'op_payout_address': '',
+            'op_reward': 0,
+            'owner_addr': 'yevc1CQmqyPWJjz1kg9KbnAvov8K3RmaYz',
+            'payout_address': 'ygeCXmn4ysXxL1DmUAcmuG5WA6QwNJbr3b',
+            'protx_hash': '',
+            'pubkey_operator': '012152114d9b7edaa5473c93858f8c11'
+                               'fa12b6f8afa37a40ed335407b207f7c8'
+                               'caa46092586c369daba06cfda00893ae',
+            'service': {
+                'ip': '127.0.0.1',
+                'port': 9999
+            },
+            'type': 1,
+            'voting_addr': 'yevc1CQmqyPWJjz1kg9KbnAvov8K3RmaYz',
+            'platform_node_id': '11' * 20,  # 20 bytes hex (40 chars)
+            'platform_p2p_port': 26656,
+            'platform_http_port': 443,
+            'platform_ed25519_privkey': '',
+            'platform_ed25519_pubkey': '',
+        }
+
+        mn = ProTxMN.from_dict(mn_dict)
+        assert mn.type == 1
+        assert mn.platform_node_id == mn_dict['platform_node_id']
+        assert mn.platform_p2p_port == mn_dict['platform_p2p_port']
+        assert mn.platform_http_port == mn_dict['platform_http_port']
+        assert mn.platform_ed25519_privkey == mn_dict['platform_ed25519_privkey']
+        assert mn.platform_ed25519_pubkey == mn_dict['platform_ed25519_pubkey']
+
         mn_dict2 = mn.as_dict()
         assert mn_dict2 == mn_dict


### PR DESCRIPTION
* Implement EvoNode (DIP3 type=1) registration flow
* Extend ProRegTx to support platform fields (Platform Node ID, P2P/HTTP ports)
* Extend ProUpServTx to support platform service updates
* Auto-generate ed25519 keypair and derive Platform Node ID
* Update DIP3 wizard UI to handle EvoNode parameters
* Improve ProRegTx / ProUpServTx handling and validation
* Manual testing performed (ProRegTx / ProUpServTx, EvoNode flow)